### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ACF Font-End Form AJAX Submit
+# ACF Front-End Form AJAX Submit
 Submit a WordPress ACF front end form via AJAX, instead of it's standard POST/page refresh method.
 
 "Disables" the refresh logic that ACF front end forms uses in favor of a custom AJAX submission. This allows you to utilize all the checks and validation that already come with ACF & ACFE and just handle the front end user interactions.
@@ -8,7 +8,7 @@ Submit a WordPress ACF front end form via AJAX, instead of it's standard POST/pa
 2. ACF Extended is also being used. If you're using ACF there's no reason to not use this, it's a straight enhancement: https://www.acf-extended.com/
 3. jQuery is queued; ACF already does this so it shouldn't be an issue.
     1. Your script should queued after jQuery, ACF and ACFE. [I recommended defering your script](https://core.trac.wordpress.org/ticket/12009#comment:57).
-5. You know how to do an AJAX hook in WP: https://codex.wordpress.org/AJAX_in_Plugins/ 
+5. You know how to do an AJAX hook in WP: https://codex.wordpress.org/AJAX_in_Plugins
 
 ## FAQ
 **Q:** Can this be done w/o jQuery? 


### PR DESCRIPTION
Fixed title typo
Removed trailing slash from WordPress URL, apparently this was redirected to a 404? Could not replicate.